### PR TITLE
Add mainProcurementCategory to test_tender_data

### DIFF
--- a/openprocurement/tender/belowthreshold/tests/base.py
+++ b/openprocurement/tender/belowthreshold/tests/base.py
@@ -81,6 +81,7 @@ test_tender_data = {
         "endDate": (now + timedelta(days=14)).isoformat()
     },
     "procurementMethodType": "belowThreshold",
+    "mainProcurementCategory": "goods",
 }
 if SANDBOX_MODE:
     test_tender_data['procurementMethodDetails'] = 'quick, accelerator=1440'

--- a/openprocurement/tender/belowthreshold/tests/tender_blanks.py
+++ b/openprocurement/tender/belowthreshold/tests/tender_blanks.py
@@ -634,9 +634,13 @@ def create_tender_generated(self):
     tender = response.json['data']
     if 'procurementMethodDetails' in tender:
         tender.pop('procurementMethodDetails')
-    self.assertEqual(set(tender), set([u'procurementMethodType', u'id', u'date', u'dateModified', u'tenderID', u'status', u'enquiryPeriod',
-                                       u'tenderPeriod', u'minimalStep', u'items', u'value', u'procuringEntity', u'next_check',
-                                       u'procurementMethod', u'awardCriteria', u'submissionMethod', u'title', u'owner']))
+    self.assertTrue(
+        {
+            u'procurementMethodType', u'id', u'date', u'dateModified', u'tenderID', u'status', u'enquiryPeriod',
+            u'tenderPeriod', u'minimalStep', u'items', u'value', u'procuringEntity', u'next_check',
+            u'procurementMethod', u'awardCriteria', u'submissionMethod', u'title', u'owner',
+        }.issubset(set(tender)),
+    )
     self.assertNotEqual(data['id'], tender['id'])
     self.assertNotEqual(data['doc_id'], tender['id'])
     self.assertNotEqual(data['tenderID'], tender['tenderID'])


### PR DESCRIPTION
test_tender_data используется для генерации документации в openprocurement.api
надо добавить туда mainProcurementCategory
Выглядит запутано учитывая, что само изменение сделано в openprocurement.tender.core
Может еще придумаем, как это собрать в кучу (не собирая в кучу код), а пока так